### PR TITLE
PubMatic : Support for InBannerVideo (IBV) Field in Bid Response

### DIFF
--- a/libraries/pbsExtensions/processors/pbs.js
+++ b/libraries/pbsExtensions/processors/pbs.js
@@ -83,6 +83,14 @@ export const PBS_PROCESSORS = {
         }
       }
     },
+    extIBV: {
+      // sets bidResponse.ext from ext.ibv
+      fn(bidResponse, bid) {
+        if (deepAccess(bid, 'ext.ibv')) {
+          bidResponse.ext = mergeDeep({}, { ibv: bid.ext.ibv }, bidResponse.ext);
+        }
+      }
+    },
   },
   [RESPONSE]: {
     serverSideStats: {

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -859,6 +859,14 @@ function _handleEids(payload, validBidRequests) {
   }
 }
 
+// Setting IBV field into the bid response
+export function setIBVField(bid, newBid) {
+  if (bid?.ext?.ibv) {
+    newBid.ext = newBid.ext || {};
+    newBid.ext['ibv'] = bid.ext.ibv;
+  }
+}
+
 function _checkMediaType(bid, newBid) {
   // Create a regex here to check the strings
   if (bid.ext && bid.ext['bidtype'] != undefined) {
@@ -1401,6 +1409,7 @@ export const spec = {
                   }
                 });
               }
+              setIBVField(bid, newBid);
               if (bid.ext && bid.ext.deal_channel) {
                 newBid['dealChannel'] = dealChannelValues[bid.ext.deal_channel] || null;
               }

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { spec, checkVideoPlacement, _getDomainFromURL, assignDealTier, prepareMetaObject, getDeviceConnectionType } from 'modules/pubmaticBidAdapter.js';
+import { spec, checkVideoPlacement, _getDomainFromURL, assignDealTier, prepareMetaObject, getDeviceConnectionType, setIBVField } from 'modules/pubmaticBidAdapter.js';
 import * as utils from 'src/utils.js';
 import { config } from 'src/config.js';
 import { createEidsArray } from 'modules/userId/eids.js';
@@ -3579,6 +3579,30 @@ describe('PubMatic adapter', function () {
         expect(response[0].renderer).to.not.exist;
       });
 
+      it('should set ibv field in bid.ext when bid.ext.ibv exists', function() {
+        let request = spec.buildRequests(bidRequests, {
+          auctionId: 'new-auction-id'
+        });
+
+        let copyOfBidResponse = utils.deepClone(bannerBidResponse);
+        let bidExt = utils.deepClone(copyOfBidResponse.body.seatbid[0].bid[0].ext);
+        copyOfBidResponse.body.seatbid[0].bid[0].ext = Object.assign(bidExt, {
+          ibv: true
+        });
+
+        let response = spec.interpretResponse(copyOfBidResponse, request);
+        expect(response[0].ext.ibv).to.equal(true);
+      });
+
+      it('should not set ibv field when bid.ext does not exist ', function() {
+        let request = spec.buildRequests(bidRequests, {
+          auctionId: 'new-auction-id'
+        });
+
+        let response = spec.interpretResponse(bannerBidResponse, request);
+        expect(response[0].ext).to.not.exist;
+      });
+
       if (FEATURES.VIDEO) {
         it('should check for valid video mediaType in case of multiformat request', function() {
           let request = spec.buildRequests(videoBidRequests, {
@@ -4174,6 +4198,52 @@ describe('PubMatic adapter', function () {
         });
         let data = JSON.parse(req.data);
         expect(data.imp[0]['banner']['battr']).to.equal(undefined);
+      });
+    });
+
+    describe('setIBVField', function() {
+      it('should set ibv field in newBid.ext when bid.ext.ibv exists', function() {
+        const bid = {
+          ext: {
+            ibv: true
+          }
+        };
+        const newBid = {};
+        setIBVField(bid, newBid);
+        expect(newBid.ext).to.exist;
+        expect(newBid.ext.ibv).to.equal(true);
+      });
+
+      it('should not set ibv field when bid.ext.ibv does not exist', function() {
+        const bid = {
+          ext: {}
+        };
+        const newBid = {};
+        setIBVField(bid, newBid);
+        expect(newBid.ext).to.not.exist;
+      });
+
+      it('should not set ibv field when bid.ext does not exist', function() {
+        const bid = {};
+        const newBid = {};
+        setIBVField(bid, newBid);
+        expect(newBid.ext).to.not.exist;
+      });
+
+      it('should preserve existing newBid.ext properties', function() {
+        const bid = {
+          ext: {
+            ibv: true
+          }
+        };
+        const newBid = {
+          ext: {
+            existingProp: 'should remain'
+          }
+        };
+        setIBVField(bid, newBid);
+        expect(newBid.ext.existingProp).to.equal('should remain');
+        expect(newBid.ext.ibv).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Implementing functionality to consume and propagate the 'ibv' field from bid.ext to the bid response
Adding the 'ibv' field in bid response enables publishers to Identify and track InBannerVideo traffic effectively
